### PR TITLE
Add "DEV" to the name of desktop app builds on Stage

### DIFF
--- a/lib/scripts/prepareForNwjs.js
+++ b/lib/scripts/prepareForNwjs.js
@@ -21,8 +21,14 @@ execute(async ({ fork }) => {
 	nwjsPkg.author = pkg.author
 	nwjsPkg.version = pkg.version
 	nwjsPkg.autoupdate = nwjsPkg.autoupdate[release]
-	if (release === 'stage' && nwjsPkg['nwjs-version'].indexOf('-sdk') === -1) {
-		nwjsPkg['nwjs-version'] = `${nwjsPkg['nwjs-version']}-sdk`
+	if (release === 'stage') {
+		// Always use the SDK version of NWJS in stage
+		if (nwjsPkg['nwjs-version'].indexOf('-sdk') === -1) {
+			nwjsPkg['nwjs-version'] = `${nwjsPkg['nwjs-version']}-sdk`
+		}
+		// Always prepend DEV to the app name in stage
+		nwjsPkg['display-name'] = `DEV ${nwjsPkg['display-name']}`
+		nwjsPkg['executable-name'] = `DEV ${nwjsPkg['executable-name']}`
 	}
 	await fs.writeFile(path.join('out', 'package.json'), JSON.stringify(nwjsPkg, null, '\t'))
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "strawbees-code",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8083,9 +8083,9 @@
       }
     },
     "strawbees-app-packager": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/strawbees-app-packager/-/strawbees-app-packager-1.4.3.tgz",
-      "integrity": "sha512-tTpZN0rNbWAVtEHHZPUcDW20KPP42VtHJIRmtHj15YoqcwGSAUm14Joz5JlCtnDQ3SimXCMC8ZTU30UGavEnow==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/strawbees-app-packager/-/strawbees-app-packager-1.4.4.tgz",
+      "integrity": "sha512-txTgVW87vfKIoYbgrRh2BIaZKLxQ6ftTBwBYFCBgWh11NkVCfek7MzkfnOrm5lNJ9D8uC8ErrvJjUzTyYcPOUw==",
       "requires": {
         "adm-zip": "^0.4.13",
         "appdmg": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "s3": "^4.4.0",
     "scratch-blocks": "^0.1.0-prerelease.1541447209",
     "serve-handler": "^5.0.5",
-    "strawbees-app-packager": "^1.4.3",
+    "strawbees-app-packager": "^1.4.4",
     "tinycolor2": "^1.4.1",
     "why-did-you-update": "^1.0.2",
     "workbox-build": "^3.6.2",


### PR DESCRIPTION
We need a clear way to see if we are running a desktop app STAGE vs PRODUCTION versions.
This PR addresses that by automatically prepending the "DEV " to the string of the display name of the app, when preparing it for the NWJS build.

Also updated to the new version of strawbees-app-packager.